### PR TITLE
Multiplex shaper decode setting

### DIFF
--- a/backend/webapp/DB/exp_data/parser/pyqum/pyqum_shaper.py
+++ b/backend/webapp/DB/exp_data/parser/pyqum/pyqum_shaper.py
@@ -122,6 +122,13 @@ class SingleQubitShape(PyqumShaper):
             for name, str_cmd in r_json.items():
                 setting_obj = SeriesStr( str_cmd )
                 settings.append( (name, np.array(setting_obj.data) ) )
+
+        # Ratis for multiplex readout
+        if "IF_ALIGN_KHZ" in p_key:
+            IF_ALIGN_KHZ = np.array(perimeter["IF_ALIGN_KHZ"].split(" ")) # list -> ndarray
+            settings.append( ("IF_ALIGN_KHZ", IF_ALIGN_KHZ) )
+
+
         # print(settings)
         if "READOUTYPE" in p_key:
             readout_mode = perimeter["READOUTYPE"]

--- a/backend/webapp/DB/exp_data/parser/pyqum/pyqum_shaper.py
+++ b/backend/webapp/DB/exp_data/parser/pyqum/pyqum_shaper.py
@@ -124,9 +124,10 @@ class SingleQubitShape(PyqumShaper):
                 settings.append( (name, np.array(setting_obj.data) ) )
 
         # Ratis for multiplex readout
-        if "IF_ALIGN_KHZ" in p_key:
-            IF_ALIGN_KHZ = np.array(perimeter["IF_ALIGN_KHZ"].split(" ")) # list -> ndarray
-            settings.append( ("IF_ALIGN_KHZ", IF_ALIGN_KHZ) )
+        if "READOUTYPE" in p_key:
+            if "IF_ALIGN_KHZ" in p_key and perimeter["READOUTYPE"]=="one-shot":
+                IF_ALIGN_KHZ = np.array(perimeter["IF_ALIGN_KHZ"].split(" ")) # list -> ndarray
+                settings.append( ("IF_ALIGN_KHZ", IF_ALIGN_KHZ) )
 
 
         # print(settings)


### PR DESCRIPTION
Only for OneShot Measurement, multiplex readout owns its different data shape (R-Json,Readout Freqs,RecordTimes/RecordSums).